### PR TITLE
Discard master and slave terminology

### DIFF
--- a/ems/apps/ems/migrations/0006_auto_20190725_1034.py
+++ b/ems/apps/ems/migrations/0006_auto_20190725_1034.py
@@ -22,7 +22,7 @@ class Migration(migrations.Migration):
             ],
         ),
         migrations.CreateModel(
-            name='Slave',
+            name='Subordinate',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('name', models.CharField(max_length=255)),
@@ -39,12 +39,12 @@ class Migration(migrations.Migration):
         ),
         migrations.AddField(
             model_name='site',
-            name='is_master',
+            name='is_main',
             field=models.BooleanField(default=1),
         ),
         migrations.AddField(
             model_name='site',
-            name='master_ip',
+            name='main_ip',
             field=models.CharField(blank=True, max_length=20, null=True),
         ),
     ]

--- a/ems/apps/ems/models.py
+++ b/ems/apps/ems/models.py
@@ -43,8 +43,8 @@ class Site(models.Model):
     name = models.CharField(max_length=255, blank=False, null=False)
     owner = models.CharField(max_length=255, blank=False, null=False)
     nms_ip = models.CharField(max_length=20, blank=False, null=False)
-    is_master = models.BooleanField(default=1, blank=False, null=False)
-    master_ip = models.CharField(max_length=20, blank=True, null=True)
+    is_main = models.BooleanField(default=1, blank=False, null=False)
+    main_ip = models.CharField(max_length=20, blank=True, null=True)
     created_on = models.DateTimeField(auto_now_add=True)
 
     def __unicode__(self):
@@ -54,7 +54,7 @@ class Site(models.Model):
         return self.name
 
 
-class Slave(models.Model):
+class Subordinate(models.Model):
     name = models.CharField(max_length=255, blank=False, null=False)
     ip_address = models.CharField(max_length=20, blank=True, null=True)
 


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.